### PR TITLE
Fix: RNN layer's h2h should be in_size=hidden_size

### DIFF
--- a/dezero/layers.py
+++ b/dezero/layers.py
@@ -231,7 +231,7 @@ class RNN(Layer):
         """
         super().__init__()
         self.x2h = Linear(hidden_size, in_size=in_size)
-        self.h2h = Linear(hidden_size, in_size=in_size, nobias=True)
+        self.h2h = Linear(hidden_size, in_size=hidden_size, nobias=True)
         self.h = None
 
     def reset_state(self):


### PR DESCRIPTION
`RNN.h2h` should be initialized with `in_size=hidden_size`.

`steps/step59.py` is currently working because it instantiates RNN with `L.RNN(hidden_size)` (i.e., `in_size=None`), but if you instantiate like `L.RNN(hidden_size, 1)`, it throws a shape mismatch error at `self.h2h(self.h)` during its forward operation.