### PR TITLE
Use buit-in type `int` instead of deprecated `np.int`

### DIFF
--- a/dezero/datasets.py
+++ b/dezero/datasets.py
@@ -47,7 +47,7 @@ def get_spiral(train=True):
     num_data, num_class, input_dim = 100, 3, 2
     data_size = num_class * num_data
     x = np.zeros((data_size, input_dim), dtype=np.float32)
-    t = np.zeros(data_size, dtype=np.int)
+    t = np.zeros(data_size, dtype=int)
 
     for j in range(num_class):
         for i in range(num_data):
@@ -137,7 +137,7 @@ class CIFAR10(Dataset):
         filepath = get_file(url)
         if self.train:
             self.data = np.empty((50000, 3 * 32 * 32))
-            self.label = np.empty((50000), dtype=np.int)
+            self.label = np.empty((50000), dtype=int)
             for i in range(5):
                 self.data[i * 10000:(i + 1) * 10000] = self._load_data(
                     filepath, i + 1, 'train')

--- a/dezero/transforms.py
+++ b/dezero/transforms.py
@@ -151,5 +151,5 @@ ToFloat = AsType
 
 
 class ToInt(AsType):
-    def __init__(self, dtype=np.int):
+    def __init__(self, dtype=int):
         self.dtype = dtype

--- a/examples/gan.py
+++ b/examples/gan.py
@@ -74,8 +74,8 @@ if use_gpu:
 else:
     xp = np
 
-label_real = xp.ones(batch_size).astype(np.int)
-label_fake = xp.zeros(batch_size).astype(np.int)
+label_real = xp.ones(batch_size).astype(int)
+label_fake = xp.zeros(batch_size).astype(int)
 test_z = xp.random.randn(25, hidden_size).astype(np.float32)
 
 


### PR DESCRIPTION
Reference from numpy:

_AttributeError: module 'numpy' has no attribute 'int'. `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:_